### PR TITLE
[Characater] 캐릭터 사망/부활 로직, 스킬 및 아이템 등 이슈 해결

### DIFF
--- a/Content/Characters/Archer/IMC_Archer.uasset
+++ b/Content/Characters/Archer/IMC_Archer.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37d004cda5278446078591e3394cd9c1ddf5e0346c2e1757e922bf8dfe66ee4f
-size 12985
+oid sha256:886592f37442c36cf898e3b1b77a3407e0e3592607c550dcc943150a989f9eac
+size 15492

--- a/Content/Characters/Priest/BP_PriestCharacter.uasset
+++ b/Content/Characters/Priest/BP_PriestCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d54d3b4b6caedd40a86d111c2f1ebb2490cc96e9b9955232281d4f59576e5e37
-size 59622
+oid sha256:967d0b2456551124bf8675002dcc17ec758baf31e8c9319d25cb6a1a0c4f2f3f
+size 59643

--- a/Content/Item/GAS/Bomb/Ice/GE_Item_Bomb_Ice.uasset
+++ b/Content/Item/GAS/Bomb/Ice/GE_Item_Bomb_Ice.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c6ab6171e6aa258f43100f33d7a242b17afe96702cac4efdcf02659467dcfb3
+oid sha256:4e7643ee43cd33963bb4f1c45b56ada83409b47b4de887c204c02e440a91c35d
 size 13885

--- a/Source/TenTenTown/Character/GAS/GA/Common/Dead/GA_CharacterDead.cpp
+++ b/Source/TenTenTown/Character/GAS/GA/Common/Dead/GA_CharacterDead.cpp
@@ -43,16 +43,21 @@ void UGA_CharacterDead::ActivateAbility(const FGameplayAbilitySpecHandle Handle,
 	Super::ActivateAbility(Handle, ActorInfo, ActivationInfo, TriggerEventData);
 	
 	ASC = GetAbilitySystemComponentFromActorInfo();
-	AvatarCharacter = Cast<ABaseCharacter>(GetAvatarActorFromActorInfo());
-	UAnimInstance* AvatarCharacterAnimInstance = AvatarCharacter->GetMesh()->GetAnimInstance();
-	UAnimMontage* DeadMontage = AvatarCharacter->GetDeathMontage();
-	LastMovementMode = AvatarCharacter->GetCharacterMovement()->GetGroundMovementMode();
+	if (!ASC) return;
 	
+	AvatarCharacter = Cast<ABaseCharacter>(GetAvatarActorFromActorInfo());
+	if (!AvatarCharacter) return;
+	
+	UAnimMontage* DeadMontage = AvatarCharacter->GetDeathMontage();
 	if (!DeadMontage)
 	{
 		GEngine->AddOnScreenDebugMessage(-1,10.f,FColor::Green,FString::Printf(TEXT("no Dead Montage in CharacterDeadAbility")));
 		return;
 	}
+	
+	LastMovementMode = AvatarCharacter->GetCharacterMovement()->GetGroundMovementMode();
+	
+	
 
 	//주요 사망처리 로직 이후 Revive에서 다시 활성화 해줘야 한다.
 	ASC->AddLooseGameplayTag(GASTAG::State_Character_Dead);

--- a/Source/TenTenTown/Character/GAS/GA/Common/Revive/GA_CharacterRevive.cpp
+++ b/Source/TenTenTown/Character/GAS/GA/Common/Revive/GA_CharacterRevive.cpp
@@ -30,8 +30,14 @@ void UGA_CharacterRevive::ActivateAbility(const FGameplayAbilitySpecHandle Handl
 	GEngine->AddOnScreenDebugMessage(-1,10.f,FColor::Green,FString::Printf(TEXT("Hello this is revive activate")));
 	
 	ASC = GetAbilitySystemComponentFromActorInfo();
+	if (!ASC) return;
+	
 	AvatarCharacter = Cast<ACharacter>(GetAvatarActorFromActorInfo());
+	if (!AvatarCharacter) return;
+	
 	ReviveMontage = Cast<ABaseCharacter>(AvatarCharacter)->GetReviveMontage();
+	if (!ReviveMontage) return;
+	
 	LastMovementMode =static_cast<EMovementMode>(TriggerEventData->EventMagnitude);
 	
 	TArray<AActor*> PlayerStartLocation;

--- a/Source/TenTenTown/Character/GAS/GA/Priest/Atonement/AtonementActor.cpp
+++ b/Source/TenTenTown/Character/GAS/GA/Priest/Atonement/AtonementActor.cpp
@@ -95,14 +95,18 @@ void AAtonementActor::OnAreaBeginOverlap(
 	{
 		CharsInArea.Add(Char);
 		
-		if (ShieldGE && !AlreadyShieldedChars.Contains(Char))
+		if (ShieldGE && !ShieldedASCs.Contains(ASC))
 		{
 			const float BaseAtk = SourceASC->GetNumericAttribute(UAS_CharacterBase::GetBaseAtkAttribute());
 			float ShieldValue = ShieldAmount + BaseAtk * ShieldMultiplier;
 			
 			ApplyGEToASC(ASC, ShieldGE, 1.f, ShieldTag, ShieldValue);
-			ApplyGEToASC(ASC, ShieldActiveGE, 1.f, ShieldActiveTag, 0);
-			AlreadyShieldedChars.Add(Char);
+			ApplyGEToASC(ASC, ShieldActiveGE, 1.f, ShieldTag, 0.f);
+			ShieldedASCs.Add(ASC);
+
+			int32& Cnt = ShieldApplyCount.FindOrAdd(ASC);
+			Cnt++;
+			UE_LOG(LogTemp, Warning, TEXT("[ShieldApply] Count=%d Target=%s ASC=%p"), Cnt, *GetNameSafe(OtherActor), ASC);
 		}
 		
 		if (SpeedUpGE)

--- a/Source/TenTenTown/Character/GAS/GA/Priest/Atonement/AtonementActor.h
+++ b/Source/TenTenTown/Character/GAS/GA/Priest/Atonement/AtonementActor.h
@@ -39,7 +39,7 @@ protected:
 	TSubclassOf<UGameplayEffect> SpeedUpGE;
 
 	UPROPERTY()
-	TSet<TWeakObjectPtr<ABaseCharacter>> AlreadyShieldedChars;
+	TSet<TWeakObjectPtr<UAbilitySystemComponent>> ShieldedASCs;
 	
 	//Enemy GE
 	UPROPERTY(EditDefaultsOnly, Category="Atonement|GAS")
@@ -88,4 +88,6 @@ protected:
 	
 	void ApplyGEToASC(UAbilitySystemComponent* TargetASC, TSubclassOf<UGameplayEffect> GEClass, float Level, FGameplayTag SetByCallerTag, float SetByCallerValue) const;
 	void RefreshGE();
+
+	TMap<TWeakObjectPtr<UAbilitySystemComponent>, int32> ShieldApplyCount;
 };

--- a/Source/TenTenTown/Character/GAS/GA/Priest/Atonement/GA_Priest_Atonement.cpp
+++ b/Source/TenTenTown/Character/GAS/GA/Priest/Atonement/GA_Priest_Atonement.cpp
@@ -65,18 +65,16 @@ void UGA_Priest_Atonement::OnMontageCancelled()
 
 void UGA_Priest_Atonement::OnSetEvent(const FGameplayEventData Payload)
 {
+	if (!CurrentActorInfo) return;
+	if (!CurrentActorInfo->IsLocallyControlled()) return;
+		
 	const ACharacter* Char = Cast<ACharacter>(GetAvatarActorFromActorInfo());
+	if (!Char) return;
+	
 	const FVector SpawnLoc = Char->GetActorLocation();
 	const FRotator SpawnRot = FRotator::ZeroRotator;
-
-	if (CurrentActorInfo->IsNetAuthority())
-	{
-		SpawnArea(SpawnLoc, SpawnRot);
-	}
-	else if (CurrentActorInfo->IsLocallyControlled())
-	{
-		Server_SpawnArea(SpawnLoc, SpawnRot);
-	}
+	
+	Server_SpawnArea(SpawnLoc, SpawnRot);
 }
 
 void UGA_Priest_Atonement::Server_SpawnArea_Implementation(const FVector& SpawnLoc, const FRotator& SpawnRot)

--- a/Source/TenTenTown/Character/GAS/GA/Priest/SacredFlash/GA_Priest_SacredFlash.cpp
+++ b/Source/TenTenTown/Character/GAS/GA/Priest/SacredFlash/GA_Priest_SacredFlash.cpp
@@ -115,11 +115,15 @@ void UGA_Priest_SacredFlash::OnShootEvent(const FGameplayEventData Payload)
 	UAbilitySystemComponent* SourceASC = UAbilitySystemGlobals::GetAbilitySystemComponentFromActor(Priest);
 	if (!SourceASC) return;
 
+	TSet<TWeakObjectPtr<AActor>> UniqueActors;
 	for (const FHitResult& Hit : HitResults)
 	{
 		AActor* HitActor = Hit.GetActor();
 		if (!HitActor) continue;
 
+		if (UniqueActors.Contains(HitActor)) continue;
+		UniqueActors.Add(HitActor);
+		
 		UAbilitySystemComponent* TargetASC = UAbilitySystemGlobals::GetAbilitySystemComponentFromActor(HitActor);
 		if (!TargetASC) continue;
 		
@@ -129,7 +133,7 @@ void UGA_Priest_SacredFlash::OnShootEvent(const FGameplayEventData Payload)
 		if (Char && ShieldGE)
 		{
 			ApplyGEToASC(SourceASC, TargetASC, ShieldGE, 1.f, ShieldTag, ShieldAmount, ShieldMultiplier);
-			ApplyGEToASC(SourceASC, TargetASC, ShieldActiveGE, 1.f, ShieldActiveTag, 0, 0);
+			ApplyGEToASC(SourceASC, TargetASC, ShieldActiveGE, 1.f, ShieldTag, 0.f, 0.f);
 		}
 		
 		if (Enemy)
@@ -149,6 +153,7 @@ void UGA_Priest_SacredFlash::ApplyGEToASC(
 	float SetByCallerMultiplier) const
 {
 	if (!SourceASC || !TargetASC || !*GEClass) return;
+	if (!SetByCallerTag.IsValid()) return;
 	
 	FGameplayEffectContextHandle Ctx = SourceASC->MakeEffectContext();
 	Ctx.AddSourceObject(this);

--- a/Source/TenTenTown/Enemy/AI/Task/MoveTask.cpp
+++ b/Source/TenTenTown/Enemy/AI/Task/MoveTask.cpp
@@ -72,7 +72,7 @@ EStateTreeRunStatus UMoveTask::Tick(FStateTreeExecutionContext& Context, const f
 		const float BaseSpeed = ASC->GetNumericAttribute(UAS_EnemyAttributeSetBase::GetMovementSpeedAttribute());
 		const float SpeedRate = ASC->GetNumericAttribute(UAS_EnemyAttributeSetBase::GetMovementSpeedRateAttribute());
 
-		MovementSpeed = FMath::Max(BaseSpeed * (1.f + SpeedRate), 0.f);
+		MovementSpeed = FMath::Max(BaseSpeed * SpeedRate, 0.f);
 	}
 	
 	float SplineLength = SplineComp->GetSplineLength();

--- a/Source/TenTenTown/Enemy/GAS/AS/AS_EnemyAttributeSetBase.cpp
+++ b/Source/TenTenTown/Enemy/GAS/AS/AS_EnemyAttributeSetBase.cpp
@@ -15,7 +15,7 @@ UAS_EnemyAttributeSetBase::UAS_EnemyAttributeSetBase()
     InitCoreAttack(77.f);
 	InitAttackSpeed(7.f);
 	InitMovementSpeed(777.f);
-	InitMovementSpeedRate(0.f);
+	InitMovementSpeedRate(1.f);
 	InitAttackRange(777.f);
 	InitGold(777.f);
 	InitExp(7.f);

--- a/Source/TenTenTown/Item/Base/BaseItem.cpp
+++ b/Source/TenTenTown/Item/Base/BaseItem.cpp
@@ -74,7 +74,7 @@ void ABaseItem::Explode()
 {
 	const FVector Origin = GetActorLocation();
 	const float Radius = ItemData.EffectRadius;
-	const float Magnitude = ItemData.Magnitude;
+	float Magnitude = ItemData.Magnitude;
 
 	DrawDebugSphere(GetWorld(), Origin, Radius, 16, FColor::Red, false, 1.0f);
 
@@ -91,6 +91,7 @@ void ABaseItem::Explode()
 		else if (ItemData.ItemTag.MatchesTagExact(FGameplayTag::RequestGameplayTag(TEXT("Data.Item.Bomb.Ice"))))
 		{
 			CueTag = FGameplayTag::RequestGameplayTag(TEXT("GameplayCue.Item.Bomb.Ice.Explode"));
+			Magnitude = (1 - (Magnitude / 100));
 		}
 		else
 		{


### PR DESCRIPTION
## 작업 내용
아이템 퀵슬롯 IA 를 IMC 에 바인딩.

캐릭터 사망 부활 크래시 이슈 해결.

에너미 이동속도 관련 로직을 수정하여 슬로우 아이템 이슈 해결.

프리스트 클래스 쉴드 이슈 해결.

## 변경 파일
GA_CharacterDead.cpp
GA_CharacterRevive.cpp

BaseItem.cpp

MoveTask.cpp
AS_EnemyAttributeSetBase.cpp

AtonementActor.h / .cpp
GA_Priest_Atonement.cpp

GA_Priest_SacredFlash.cpp